### PR TITLE
Fix admin dashboard API url handling

### DIFF
--- a/admin_dashboard/src/Components/DataTable/DataTable.jsx
+++ b/admin_dashboard/src/Components/DataTable/DataTable.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/img-redundant-alt */
 import { DataGrid } from '@mui/x-data-grid';
 import axios from 'axios';
+import { API_BASE_URL } from '../utils/api';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import noImage from '../../Images/user.png';
@@ -17,7 +18,7 @@ function DataTable() {
 data. */
     useEffect(() => {
         const dataCall = async () => {
-            const res = await axios.get(`https://rooms-backend.onrender.com/api/${path}`);
+            const res = await axios.get(`${API_BASE_URL}/${path}`);
             setData(res.data.message.slice(1));
         };
         dataCall();
@@ -29,7 +30,7 @@ data. */
      */
     const handleDlt = async (id) => {
         try {
-            axios.delete(`https://rooms-backend.onrender.com/api/${path}/${id}`);
+            axios.delete(`${API_BASE_URL}/${path}/${id}`);
             setData(data.filter((item) => item.id !== id));
         } catch (error) {
             console.log(error);

--- a/admin_dashboard/src/Components/ItemLists/ItemLists.jsx
+++ b/admin_dashboard/src/Components/ItemLists/ItemLists.jsx
@@ -4,6 +4,7 @@ import LocalGroceryStoreOutlinedIcon from '@mui/icons-material/LocalGroceryStore
 import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
 import PermIdentityIcon from '@mui/icons-material/PermIdentity';
 import axios from 'axios';
+import { API_BASE_URL } from '../utils/api';
 import React, { useEffect, useState } from 'react';
 import CountUp from 'react-countup';
 import { Link } from 'react-router-dom';
@@ -19,9 +20,9 @@ function ItemLists({ type }) {
    is used to fetch data from three different API endpoints with the response data. */
     useEffect(() => {
         const datass = async () => {
-            const res = await axios.get('https://rooms-backend.onrender.com/api/hotels');
-            const res2 = await axios.get('https://rooms-backend.onrender.com/api/blogs');
-            const res3 = await axios.get('https://rooms-backend.onrender.com/api/users');
+            const res = await axios.get(`${API_BASE_URL}/hotels`);
+            const res2 = await axios.get(`${API_BASE_URL}/blogs`);
+            const res3 = await axios.get(`${API_BASE_URL}/users`);
             setHotelData(res.data.message);
             setBlogData(res2.data.message);
             setUserData(res3.data.message);

--- a/admin_dashboard/src/Components/ProgressBar/ProgressBar.jsx
+++ b/admin_dashboard/src/Components/ProgressBar/ProgressBar.jsx
@@ -8,6 +8,7 @@ import 'react-circular-progressbar/dist/styles.css';
 import './progressBar.scss';
 
 import axios from 'axios';
+import { API_BASE_URL } from '../utils/api';
 import { Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
 
 function ProgressBar() {
@@ -21,10 +22,10 @@ function ProgressBar() {
    (`userData`, `hotelData`, `blogData`, `roomData`) with the received data. */
     useEffect(() => {
         const datass = async () => {
-            const res = await axios.get('https://rooms-backend.onrender.com/api/rooms');
-            const res2 = await axios.get('https://rooms-backend.onrender.com/api/blogs');
-            const res3 = await axios.get('https://rooms-backend.onrender.com/api/users');
-            const res4 = await axios.get('https://rooms-backend.onrender.com/api/rooms');
+            const res = await axios.get(`${API_BASE_URL}/rooms`);
+            const res2 = await axios.get(`${API_BASE_URL}/blogs`);
+            const res3 = await axios.get(`${API_BASE_URL}/users`);
+            const res4 = await axios.get(`${API_BASE_URL}/rooms`);
             setHotelData(res.data.message);
             setBlogData(res2.data.message);
             setUserData(res3.data.message);

--- a/admin_dashboard/src/Pages/AddHotel/AddHotel.jsx
+++ b/admin_dashboard/src/Pages/AddHotel/AddHotel.jsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Input from '../../Components/Input/Input';
@@ -32,11 +33,11 @@ function AddHotel({ inputs, title, type }) {
     const nevigate = useNavigate();
 
     /* The `useEffect` hook is used to perform side effects in a functional component. In this case, it
-   is used to fetch data from the API endpoint `'https://rooms-backend.onrender.com/api/rooms'` and
+   is used to fetch room data from the API endpoint and
    update the state variable `roomData` with the response data. */
     useEffect(() => {
         const roomsss = async () => {
-            const room = await axios.get('https://rooms-backend.onrender.com/api/rooms');
+            const room = await axios.get(`${API_BASE_URL}/rooms`);
             setroomData(room.data.message);
         };
         roomsss();
@@ -87,7 +88,7 @@ function AddHotel({ inputs, title, type }) {
                 images: imgList,
             };
 
-            await axios.post('https://rooms-backend.onrender.com/api/hotel/create', newHotel);
+            await axios.post(`${API_BASE_URL}/hotel/create`, newHotel);
             setLoading(false);
             nevigate(`/hotels`);
         } catch (error) {

--- a/admin_dashboard/src/Pages/AddNew/AddNew.jsx
+++ b/admin_dashboard/src/Pages/AddNew/AddNew.jsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Input from '../../Components/Input/Input';
@@ -79,7 +80,7 @@ function AddNew({ inputs, title, type }) {
             }
 
             await axios.post(
-                `https://rooms-backend.onrender.com/api/${
+                `${API_BASE_URL}/${
                     type === 'USER' ? 'user/signup' : 'blog/create'
                 }`,
                 userInp

--- a/admin_dashboard/src/Pages/AddRoom/AddRoom.jsx
+++ b/admin_dashboard/src/Pages/AddRoom/AddRoom.jsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
+import { API_BASE_URL } from '../../utils/api';
 import { useNavigate } from 'react-router-dom';
 import Input from '../../Components/Input/Input';
 import Navbar from '../../Components/Navbar/Navbar';
@@ -24,11 +25,11 @@ function AddRoom({ inputs, title, type }) {
     const nevigate = useNavigate();
 
     /* The `useEffect` hook is used to perform side effects in a functional component. In this case, it
-   is used to fetch data from the API endpoint `'https://rooms-backend.onrender.com/api/hotels'` and
+   is used to fetch data from the API endpoint and
    update the state variables `roomData` with the response data. */
     useEffect(() => {
         const roomsss = async () => {
-            const hotel = await axios.get('https://rooms-backend.onrender.com/api/hotels');
+            const hotel = await axios.get(`${API_BASE_URL}/hotels`);
             setRoomData(hotel.data.message);
         };
         roomsss();
@@ -54,7 +55,7 @@ function AddRoom({ inputs, title, type }) {
         try {
             setLoading(true);
 
-            await axios.post(`https://rooms-backend.onrender.com/api/room/${hotelId}`, datas);
+            await axios.post(`${API_BASE_URL}/room/${hotelId}`, datas);
 
             setLoading(false);
             nevigate(`/rooms`);

--- a/admin_dashboard/src/Pages/Blogs/Blogs.jsx
+++ b/admin_dashboard/src/Pages/Blogs/Blogs.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-nested-ternary */
 import { DataGrid } from '@mui/x-data-grid';
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Navbar from '../../Components/Navbar/Navbar';
@@ -70,7 +71,7 @@ function Blogs({ type }) {
    data. */
     useEffect(() => {
         const getData = async () => {
-            const datas = await axios.get('https://rooms-backend.onrender.com/api/blogs');
+            const datas = await axios.get(`${API_BASE_URL}/blogs`);
             setData(datas.data.message);
         };
         getData();
@@ -82,7 +83,7 @@ function Blogs({ type }) {
      */
     const handleDlt = (id) => {
         try {
-            axios.delete(`https://rooms-backend.onrender.com/api/${path}/${id}`);
+            axios.delete(`${API_BASE_URL}/${path}/${id}`);
             setData(data.filter((item) => item.id !== id));
             console.log(`deleted user ${id}`);
         } catch (error) {

--- a/admin_dashboard/src/Pages/Detail/Detail.jsx
+++ b/admin_dashboard/src/Pages/Detail/Detail.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import Chart from '../../Components/Chart/Chart';
@@ -21,7 +22,7 @@ function Detail() {
     useEffect(() => {
         setLoading(true);
         const fetchData = async () => {
-            const data = await axios.get(`https://rooms-backend.onrender.com/api/user/${path}`);
+            const data = await axios.get(`${API_BASE_URL}/user/${path}`);
             setUserData(data.data.message);
         };
         fetchData();

--- a/admin_dashboard/src/Pages/Hotels/Hotels.jsx
+++ b/admin_dashboard/src/Pages/Hotels/Hotels.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-nested-ternary */
 import { DataGrid } from '@mui/x-data-grid';
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Navbar from '../../Components/Navbar/Navbar';
@@ -82,7 +83,7 @@ function Hotels({ type }) {
    effect is triggered when the `data` state variable changes. */
     useEffect(() => {
         const datass = async () => {
-            const res = await axios.get('https://rooms-backend.onrender.com/api/hotels');
+            const res = await axios.get(`${API_BASE_URL}/hotels`);
             setData(res.data.message);
         };
         datass();
@@ -94,7 +95,7 @@ function Hotels({ type }) {
      */
     const handleDlt = (id) => {
         try {
-            axios.delete(`https://rooms-backend.onrender.com/api/${path}/${id}`);
+            axios.delete(`${API_BASE_URL}/${path}/${id}`);
             setData(data.filter((item) => item.id !== id));
             console.log(`deleted user ${id}`);
         } catch (error) {

--- a/admin_dashboard/src/Pages/Login/Login.jsx
+++ b/admin_dashboard/src/Pages/Login/Login.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import axios from 'axios';
 import React, { useContext, useState } from 'react';
+import { API_BASE_URL } from '../../utils/api';
 import { useNavigate } from 'react-router-dom';
 import { Contexts } from '../../ContextUser/Contexts';
 import './Login.scss';
@@ -28,7 +29,7 @@ const index = () => {
         setLoginLoading(true);
 
         try {
-            const res = await axios.post('http://localhost:5001/api/user/login', inpVal);
+            const res = await axios.post(`${API_BASE_URL}/user/login`, inpVal);
 
             console.log(res.data.message.details);
             localStorage.setItem('user', JSON.stringify(res.data.message.details.username));

--- a/admin_dashboard/src/Pages/Rooms/Rooms.jsx
+++ b/admin_dashboard/src/Pages/Rooms/Rooms.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-nested-ternary */
 import { DataGrid } from '@mui/x-data-grid';
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Navbar from '../../Components/Navbar/Navbar';
@@ -17,7 +18,7 @@ function Rooms({ type }) {
    effect is triggered when the `data` state variable changes. */
     useEffect(() => {
         const datass = async () => {
-            const res = await axios.get('https://rooms-backend.onrender.com/api/rooms');
+            const res = await axios.get(`${API_BASE_URL}/rooms`);
             setData(res.data.message);
         };
         datass();
@@ -29,7 +30,7 @@ function Rooms({ type }) {
      */
     const handleDlt = (id) => {
         try {
-            axios.delete(`https://rooms-backend.onrender.com/api/${path}/${id}`);
+            axios.delete(`${API_BASE_URL}/${path}/${id}`);
             setData(data.filter((item) => item.id !== id));
             console.log(`deleted room ${id}`);
         } catch (error) {

--- a/admin_dashboard/src/utils/api.js
+++ b/admin_dashboard/src/utils/api.js
@@ -1,0 +1,3 @@
+export const API_BASE_URL =
+    process.env.REACT_APP_API_URL || 'http://localhost:5001/api';
+

--- a/client/pages/blogs/[blog].js
+++ b/client/pages/blogs/[blog].js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import Image from 'next/image';
 import React from 'react';
 import { FaCalendarAlt, FaRegEye } from 'react-icons/fa';
@@ -75,7 +76,7 @@ export default blogDetails;
 // based on the response data.
 // @returns an object with two properties: "paths" and "fallback".
 export async function getStaticPaths() {
-    const response = await axios.get(`https://rooms-backend.onrender.com/api/blogs`);
+    const response = await axios.get(`${API_BASE_URL}/blogs`);
     const data = await response.data.message;
 
     const paths = data.map((item) => ({
@@ -97,8 +98,8 @@ export async function getStaticProps(context) {
     // api route
     const { params } = context;
     console.log(params);
-    const res = await axios.get(`https://rooms-backend.onrender.com/api/blog/${params.blog}`);
-    const res2 = await axios.get('https://rooms-backend.onrender.com/api/blogs');
+    const res = await axios.get(`${API_BASE_URL}/blog/${params.blog}`);
+    const res2 = await axios.get(`${API_BASE_URL}/blogs`);
 
     const data = await res.data.message;
     const blogss = await res2.data.message;

--- a/client/pages/hotels/[hotel].js
+++ b/client/pages/hotels/[hotel].js
@@ -11,6 +11,7 @@ import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 // import required modules
 import axios from 'axios';
+import { API_BASE_URL } from '../../utils/api';
 import Link from 'next/link';
 import { useContext, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -238,7 +239,7 @@ export default hotelDetails;
 // hotel's ID. The "fallback" property is set to false, indicating that any paths not returned in the
 // "paths" array will result in a 404 page.
 export async function getStaticPaths() {
-    const response = await axios.get(`https://rooms-backend.onrender.com/api/hotels`);
+    const response = await axios.get(`${API_BASE_URL}/hotels`);
     const data = await response.data.message;
 
     const paths = data.map((item) => ({
@@ -259,8 +260,8 @@ export async function getStaticPaths() {
 export async function getStaticProps(context) {
     // api route
     const { params } = context;
-    const res = await axios.get(`https://rooms-backend.onrender.com/api/hotel/${params.hotel}`);
-    const res2 = await axios.get(`https://rooms-backend.onrender.com/api/rooms/${params.hotel}`);
+    const res = await axios.get(`${API_BASE_URL}/hotel/${params.hotel}`);
+    const res2 = await axios.get(`${API_BASE_URL}/rooms/${params.hotel}`);
 
     const data = await res.data.message;
     const data2 = await res2.data.message;

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -97,6 +97,7 @@
 // }
 
 import axios from 'axios';
+import { API_BASE_URL } from '../utils/api';
 import Head from 'next/head';
 import BlogComponent from '../components/BlogComponent/BlogComponent';
 import Features from '../components/Features/Features';
@@ -143,7 +144,7 @@ export async function getStaticProps() {
 
   try {
     const response = await axios.get(
-      'https://rooms-backend.onrender.com/api/hotels/getHotelByCity?cities=berlin,tokyo,dubai'
+      `${API_BASE_URL}/hotels/getHotelByCity?cities=berlin,tokyo,dubai`
     );
     propertyList = response.data.message || [];
   } catch (error) {
@@ -153,7 +154,7 @@ export async function getStaticProps() {
 
   try {
     const response2 = await axios.get(
-      'https://rooms-backend.onrender.com/api/hotels/getHotelByType'
+      `${API_BASE_URL}/hotels/getHotelByType`
     );
     propertyList2 = response2.data.message || [];
   } catch (error) {
@@ -162,7 +163,7 @@ export async function getStaticProps() {
 
   try {
     const response3 = await axios.get(
-      'https://rooms-backend.onrender.com/api/hotels?featured=true&limit=4'
+      `${API_BASE_URL}/hotels?featured=true&limit=4`
     );
     homesDetails = response3.data.message || [];
   } catch (error) {
@@ -170,7 +171,7 @@ export async function getStaticProps() {
   }
 
   try {
-    const res = await axios.get('https://rooms-backend.onrender.com/api/blogs');
+    const res = await axios.get(`${API_BASE_URL}/blogs`);
     blogss = res.data.message || [];
   } catch (error) {
     console.error('Error fetching blogs:', error.message);

--- a/client/utils/api.js
+++ b/client/utils/api.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5001/api';


### PR DESCRIPTION
## Summary
- centralize API base URL
- use the constant in AddHotel, AddRoom and Login
- change default base URL to port 5001

## Testing
- `CI=true npm test --prefix admin_dashboard` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840901f2d8c83228e80550feb7386a5